### PR TITLE
feat: add generic custom rating provider support

### DIFF
--- a/README.en.md
+++ b/README.en.md
@@ -94,12 +94,42 @@ pinned: false
 * **Official Network Logos**: Automatic detection and embedding for Netflix, Prime Video, Disney+, Apple TV+, HBO Max, Paramount+, Sky/NOW, Crunchyroll, and 30+ studios (Marvel, Pixar, Ghibli, Warner Bros, A24).
 
 ### 🏷️ Badges, Ratings & Accolades
+
+- **Custom Rating Provider**: Connect any external rating API using an IMDb ID through server-side configuration and render its ratings as separate pills, each with decimal or percentage formatting. Provider failures are non-blocking and never prevent the poster from rendering.
 * **✨ Streaming Quality (4K / FHD / HD / SD)**: Detected live from Stremio video streams with automatic fallback to JustWatch.
 * **6 Genre & Rating Badge Styles**: *Shadow, Pill, Bar, Colored, Border, Glass* with adaptive palette matching the poster.
 * **Vertical Netflix Top 10 Ribbon**: The iconic red side ribbon with live rank position (dedicated support for Anime).
 * **Film Awards & Accolades**: Automatic recognition of Oscars, Cannes, BAFTA, Emmy, and the *"Absolute Cinema"* badge for IMDb Top 250 titles.
 * **Always-in-Sync Charts**: Top 10/20 badges track live charts; if a title leaves the ranking, its badge updates automatically.
 * **✨ Pre-Digital Effect (Coming Soon)**: For movies out in theaters but not yet streaming (detected via JustWatch with fallback to the TMDB digital date): darkened poster with a red "Coming Soon" corner ribbon. Movies only, default OFF; enable per-title, via `?pre=1`, config token or environment variable.
+
+### 🔌 Custom Rating Provider
+
+Pictorium can optionally fetch multiple ratings from any external HTTP(S) API using the title's IMDb ID.
+
+Example endpoint:
+```text
+https://example.com/ratings/{imdbId}
+```
+
+Expected response:
+```json
+{
+  "ratings": [
+    { "id": "source1", "name": "Source 1", "value": 8.8, "format": "decimal" },
+    { "id": "source2", "name": "Source 2", "value": 87, "format": "percent" }
+  ]
+}
+```
+
+The provider supports any number of rating items, optional API-key authentication
+via HTTP header, and fails gracefully without blocking poster generation.
+
+Configuration is currently server-side. Web/editor configuration is intentionally
+left out of this change so the backend feature stays focused and easy to review.
+
+For full configuration and API details, see
+[Custom Rating Provider documentation](docs/custom-rating.md).
 
 ### 📺 Seasons, Episodes & Anime
 * **✨ Automatic Parts Detection**: Automatically maps standard seasons to original Parts for series like *Money Heist / La Casa de Papel* (5 parts) and *Lupin* (4 parts).

--- a/README.en.md
+++ b/README.en.md
@@ -127,6 +127,9 @@ via HTTP header, and fails gracefully without blocking poster generation.
 
 Configuration is currently server-side. Web/editor configuration is intentionally
 left out of this change so the backend feature stays focused and easy to review.
+Use `PICTORIUM_CUSTOM_RATING_ENABLED`, `PICTORIUM_CUSTOM_RATING_ENDPOINT`,
+`PICTORIUM_CUSTOM_RATING_API_KEY`, and `PICTORIUM_CUSTOM_RATING_API_KEY_HEADER`.
+The existing `POSTERIUM_` prefix remains a fallback; `PICTORIUM_` takes precedence.
 
 For full configuration and API details, see
 [Custom Rating Provider documentation](docs/custom-rating.md).

--- a/docs/custom-rating.md
+++ b/docs/custom-rating.md
@@ -60,12 +60,17 @@ and a 16 KiB response limit. Only public HTTP(S) destinations are supported:
 private/loopback/link-local addresses are blocked at connection time, URL
 credentials and redirects are rejected. Configure secrets through the header,
 never in the endpoint URL. Provider errors are not logged.
+API-key authentication requires HTTPS. An HTTP endpoint with a configured API
+key is rejected without making a request and returns `[]`; HTTP without an API
+key remains supported.
 
 Poster cache hits return before custom fetching. On a miss, fetching runs with
 luminance and optional metadata work after IMDb ID resolution. A SHA-256 digest
 of enabled configuration participates in poster cache identity, including key
 changes without storing plaintext secrets in cache keys. There is no additional
 rating cache; freshness follows the existing poster TTL. Restart after env changes.
+Enabled custom ratings use the existing normal poster HTTP cache policy, including
+for saved mappings with versioned URLs; they never use one-year immutable caching.
 
 `GenerationInput.ratings?: RatingItem[]` supports any number of ratings in a
 horizontal row that scales to the available width. Omission preserves the old

--- a/docs/custom-rating.md
+++ b/docs/custom-rating.md
@@ -1,0 +1,76 @@
+# Custom Rating Provider
+
+Optional backend enrichment from any external rating service, using IMDb IDs.
+The existing TMDb/MDBList `voteAverage` badge remains unchanged. Custom ratings
+appear in a separate horizontal pill row above the existing bottom badge.
+When disabled, no multi-rating row is rendered. When enabled, available internal
+IMDb data is combined with the provider items for non-mapped, saved and query posters.
+
+## Configuration
+
+Configuration is currently server-side via environment variables.
+
+| Environment variable | Default | Purpose |
+| --- | --- | --- |
+| `CUSTOM_RATING_ENABLED` | `false` | Enable with `true` or `1` |
+| `CUSTOM_RATING_ENDPOINT` | empty | HTTP(S) URL containing `{imdbId}` |
+| `CUSTOM_RATING_API_KEY` | unset | Optional secret sent only in a header |
+| `CUSTOM_RATING_API_KEY_HEADER` | `X-API-Key` | Header for the secret |
+
+Example endpoint: `https://example.com/ratings/{imdbId}`.
+For IMDb ID `tt1375666`, Pictorium sends:
+
+```http
+GET /ratings/tt1375666 HTTP/1.1
+Host: example.com
+Accept: application/json
+X-API-Key: <configured secret, if any>
+```
+
+Required response contract:
+
+```json
+{
+  "ratings": [
+    { "id": "source1", "name": "Source 1", "value": 8.8, "format": "decimal" },
+    { "id": "source2", "name": "Source 2", "value": 87, "format": "percent" }
+  ]
+}
+```
+
+`fetchCustomRatings(imdbId, config, signal?)` returns `RatingItem[]`. There is no
+fixed item count, subject to the response size limit below. Every item is validated
+independently: `id` and `name` must be non-empty strings after trimming, `value`
+must be a finite number, and `format` must be `decimal` or `percent`. Invalid items
+are ignored; an empty or entirely invalid array returns `[]`. Extra fields are
+ignored. Percent renders `87` as `87%`; decimal renders `8.8` as `8.8`, without
+scale conversion. Names and formats come from the API.
+
+IDs are case-sensitive and trimmed. For duplicate IDs, the last valid API item
+wins while retaining the first occurrence's position. Provider items override
+internal items with the same ID. The internal IMDb slot stays first when present;
+remaining provider items follow API order. Invalid duplicates never erase a valid item.
+
+Errors, invalid JSON, non-2xx responses and timeouts return `[]` and must never
+prevent poster rendering. The
+request has a 1.5-second timeout combined with the main render AbortSignal,
+and a 16 KiB response limit. Only public HTTP(S) destinations are supported:
+private/loopback/link-local addresses are blocked at connection time, URL
+credentials and redirects are rejected. Configure secrets through the header,
+never in the endpoint URL. Provider errors are not logged.
+
+Poster cache hits return before custom fetching. On a miss, fetching runs with
+luminance and optional metadata work after IMDb ID resolution. A SHA-256 digest
+of enabled configuration participates in poster cache identity, including key
+changes without storing plaintext secrets in cache keys. There is no additional
+rating cache; freshness follows the existing poster TTL. Restart after env changes.
+
+`GenerationInput.ratings?: RatingItem[]` supports any number of ratings in a
+horizontal row that scales to the available width. Omission preserves the old
+renderer. Each item has `id`, `name`, `value`, `format`, and optional `logo`.
+Logo is reserved for later trusted assets; this phase renders the name as text.
+The renderer already supports multiple rating pills. Web/editor configuration
+is not part of this backend change. Future editor integration can expose the
+endpoint, API key/header and related settings through
+`resolveCustomRatingConfig(overrides)`. Asset uploads are also left for a separate
+change; no public endpoint or token schema changes here.

--- a/docs/custom-rating.md
+++ b/docs/custom-rating.md
@@ -9,13 +9,15 @@ IMDb data is combined with the provider items for non-mapped, saved and query po
 ## Configuration
 
 Configuration is currently server-side via environment variables.
+The canonical prefix is `PICTORIUM_`; `POSTERIUM_` is supported as a legacy
+fallback through `envWithFallback()`. Canonical values take precedence.
 
 | Environment variable | Default | Purpose |
 | --- | --- | --- |
-| `CUSTOM_RATING_ENABLED` | `false` | Enable with `true` or `1` |
-| `CUSTOM_RATING_ENDPOINT` | empty | HTTP(S) URL containing `{imdbId}` |
-| `CUSTOM_RATING_API_KEY` | unset | Optional secret sent only in a header |
-| `CUSTOM_RATING_API_KEY_HEADER` | `X-API-Key` | Header for the secret |
+| `PICTORIUM_CUSTOM_RATING_ENABLED` | `false` | Enable with `true` or `1` |
+| `PICTORIUM_CUSTOM_RATING_ENDPOINT` | empty | HTTP(S) URL containing `{imdbId}` |
+| `PICTORIUM_CUSTOM_RATING_API_KEY` | unset | Optional secret sent only in a header |
+| `PICTORIUM_CUSTOM_RATING_API_KEY_HEADER` | `X-API-Key` | Header for the secret |
 
 Example endpoint: `https://example.com/ratings/{imdbId}`.
 For IMDb ID `tt1375666`, Pictorium sends:

--- a/src/__tests__/custom-rating.test.ts
+++ b/src/__tests__/custom-rating.test.ts
@@ -88,6 +88,18 @@ describe("custom rating", () => {
     vi.stubEnv("PICTORIUM_CUSTOM_RATING_ENABLED", "true")
     expect(resolveCustomRatingConfig({ endpoint: "https://other.example/{imdbId}" })).toMatchObject({ enabled: true, endpoint: "https://other.example/{imdbId}", apiKeyHeader: "X-API-Key" })
   })
+  it("rejects HTTP with an API key before making a request", async () => {
+    respond(JSON.stringify({ ratings: [sample] }))
+    expect(await fetchCustomRatings("tt123", {
+      ...config, endpoint: "http://example.com/{imdbId}", apiKey: "test-secret",
+    })).toEqual([])
+    expect(mockedRequest).not.toHaveBeenCalled()
+  })
+  it.each(["http", "https"])("allows %s without an API key", async protocol => {
+    respond(JSON.stringify({ ratings: [sample] }))
+    expect(await fetchCustomRatings("tt123", { ...config, endpoint: `${protocol}://example.com/{imdbId}` })).toEqual([sample])
+    expect(mockedRequest).toHaveBeenCalledTimes(1)
+  })
   it.each(["PICTORIUM", "POSTERIUM"])("resolves all custom rating settings from %s", prefix => {
     const values = {
       CUSTOM_RATING_ENABLED: "1", CUSTOM_RATING_ENDPOINT: "https://example.com/{imdbId}",

--- a/src/__tests__/custom-rating.test.ts
+++ b/src/__tests__/custom-rating.test.ts
@@ -85,8 +85,30 @@ describe("custom rating", () => {
     expect(mockedRequest).not.toHaveBeenCalled()
   })
   it("resolves env with future explicit overrides", () => {
-    vi.stubEnv("CUSTOM_RATING_ENABLED", "true")
+    vi.stubEnv("PICTORIUM_CUSTOM_RATING_ENABLED", "true")
     expect(resolveCustomRatingConfig({ endpoint: "https://other.example/{imdbId}" })).toMatchObject({ enabled: true, endpoint: "https://other.example/{imdbId}", apiKeyHeader: "X-API-Key" })
+  })
+  it.each(["PICTORIUM", "POSTERIUM"])("resolves all custom rating settings from %s", prefix => {
+    const values = {
+      CUSTOM_RATING_ENABLED: "1", CUSTOM_RATING_ENDPOINT: "https://example.com/{imdbId}",
+      CUSTOM_RATING_API_KEY: "test-key", CUSTOM_RATING_API_KEY_HEADER: "Authorization",
+    }
+    for (const [suffix, value] of Object.entries(values)) {
+      vi.stubEnv(`PICTORIUM_${suffix}`, undefined)
+      vi.stubEnv(`POSTERIUM_${suffix}`, undefined)
+      vi.stubEnv(`${prefix}_${suffix}`, value)
+    }
+    expect(resolveCustomRatingConfig()).toEqual({
+      enabled: true, endpoint: values.CUSTOM_RATING_ENDPOINT, apiKey: "test-key", apiKeyHeader: "Authorization",
+    })
+  })
+  it("prefers canonical settings over legacy fallback, including disabled and empty values", () => {
+    for (const suffix of ["CUSTOM_RATING_ENABLED", "CUSTOM_RATING_ENDPOINT", "CUSTOM_RATING_API_KEY", "CUSTOM_RATING_API_KEY_HEADER"]) {
+      vi.stubEnv(`POSTERIUM_${suffix}`, "legacy")
+      vi.stubEnv(`PICTORIUM_${suffix}`, "")
+    }
+    vi.stubEnv("PICTORIUM_CUSTOM_RATING_ENABLED", "false")
+    expect(resolveCustomRatingConfig()).toEqual({ enabled: false, endpoint: "", apiKey: undefined, apiKeyHeader: "X-API-Key" })
   })
   it.each(["::ffff:127.0.0.1", "::ffff:10.0.0.1", "::ffff:93.184.216.34"])("blocks IPv4-mapped IPv6 endpoint %s before requesting", async address => {
     respond('{"invalid":87}')

--- a/src/__tests__/custom-rating.test.ts
+++ b/src/__tests__/custom-rating.test.ts
@@ -1,0 +1,117 @@
+// @vitest-environment node
+import { Readable } from "node:stream"
+import { afterEach, describe, expect, it, vi } from "vitest"
+import { request } from "undici"
+import { fetchCustomRatings, formatRating, resolveCustomRatingConfig } from "@/lib/custom-rating"
+import { renderMultiRatings } from "@/lib/multi-rating-renderer"
+import sharp from "sharp"
+import type { LookupFunction } from "node:net"
+import { lookup } from "node:dns"
+
+const connection = vi.hoisted(() => ({ lookup: undefined as LookupFunction | undefined }))
+vi.mock("node:dns", () => ({ lookup: vi.fn() }))
+vi.mock("undici", () => ({ Agent: class {
+  constructor(options: { connect: { lookup: LookupFunction } }) { connection.lookup = options.connect.lookup }
+}, request: vi.fn() }))
+const config = { enabled: true, endpoint: "https://example.com/ratings/{imdbId}" }
+const sample = { id: "source1", name: "Source 1", value: 8.8, format: "decimal" }
+const mockedRequest = vi.mocked(request)
+function respond(body: string, statusCode = 200) {
+  mockedRequest.mockResolvedValue({ statusCode, body: Readable.from([Buffer.from(body)]) } as unknown as Awaited<ReturnType<typeof request>>)
+}
+afterEach(() => vi.clearAllMocks())
+
+describe("custom rating", () => {
+  it("validates the response and sends the secret only in the configured header", async () => {
+    respond(JSON.stringify({ ratings: [sample] }))
+    expect(await fetchCustomRatings("tt1375666", { ...config, apiKey: "test-secret" })).toEqual([sample])
+    const [url, options] = mockedRequest.mock.calls[0]
+    expect(String(url)).toBe("https://example.com/ratings/tt1375666")
+    expect(options?.headers).toMatchObject({ "X-API-Key": "test-secret" })
+  })
+  it("formats without changing the scale", () => {
+    expect(formatRating(87, "percent")).toBe("87%")
+    expect(formatRating(8.7, "decimal")).toBe("8.7")
+  })
+  it.each(['bad json', '{"invalid":87}', '{"ratings":null}', '{"ratings":{}}', '{}', '{"ratings":[{"id":"a","name":"A","value":1e999,"format":"decimal"}]}', '[]', 'x'.repeat(16385)])("ignores invalid or oversized data %#", async body => {
+    respond(body)
+    expect(await fetchCustomRatings("tt123", config)).toEqual([])
+  })
+  it.each([0, 1, 2, 5])("accepts %i ratings without a fixed item count", async count => {
+    const ratings = Array.from({ length: count }, (_, index) => ({ ...sample, id: `source${index}`, name: `Source ${index}` }))
+    respond(JSON.stringify({ ratings }))
+    expect(await fetchCustomRatings("tt123", config)).toEqual(ratings)
+  })
+  it("ignores invalid items individually", async () => {
+    const other = { id: "source2", name: "Source 2", value: 87, format: "percent" }
+    respond(JSON.stringify({ ratings: [null, [], "bad", {}, sample,
+      { ...sample, id: " " }, { ...sample, id: 1 }, { ...sample, name: "" },
+      { ...sample, name: false }, { ...sample, value: "87" }, { ...sample, value: null },
+      { ...sample, format: "stars" }, other] }))
+    expect(await fetchCustomRatings("tt123", config)).toEqual([sample, other])
+  })
+  it("returns an empty array for invalid formats", async () => {
+    respond(JSON.stringify({ ratings: [{ ...sample, format: "stars" }, { ...sample, format: null }] }))
+    expect(await fetchCustomRatings("tt123", config)).toEqual([])
+  })
+  it("keeps the last valid duplicate at the first position after trimming IDs", async () => {
+    const replacement = { ...sample, name: "Updated", value: 9 }
+    const other = { ...sample, id: "source2" }
+    respond(JSON.stringify({ ratings: [sample, other, { ...replacement, id: " source1 " }, { ...sample, format: "invalid" }] }))
+    expect(await fetchCustomRatings("tt123", config)).toEqual([replacement, other])
+  })
+  it("ignores API errors", async () => {
+    respond('{"invalid":87}', 503)
+    expect(await fetchCustomRatings("tt123", config)).toEqual([])
+    mockedRequest.mockRejectedValueOnce(new Error("network"))
+    expect(await fetchCustomRatings("tt123", config)).toEqual([])
+  })
+  it("times out and respects caller cancellation", async () => {
+    mockedRequest.mockImplementation((_url, options) => new Promise((_resolve, reject) => {
+      ;(options?.signal as AbortSignal)?.addEventListener("abort", () => reject(new Error("aborted")), { once: true })
+    }))
+    expect(await fetchCustomRatings("tt123", config)).toEqual([])
+    const controller = new AbortController()
+    const pending = fetchCustomRatings("tt123", config, controller.signal)
+    controller.abort()
+    expect(await pending).toEqual([])
+  })
+  it("does not request disabled, missing ID or unsafe endpoints", async () => {
+    expect(await fetchCustomRatings("tt123", { ...config, enabled: false })).toEqual([])
+    expect(await fetchCustomRatings(null, config)).toEqual([])
+    for (const endpoint of ["file:///{imdbId}", "https://example.com/no-placeholder", "http://127.0.0.1/{imdbId}", "http://[::1]/{imdbId}", "http://[::ffff:127.0.0.1]/{imdbId}", "http://169.254.169.254/{imdbId}"]) {
+      expect(await fetchCustomRatings("tt123", { ...config, endpoint })).toEqual([])
+    }
+    expect(mockedRequest).not.toHaveBeenCalled()
+  })
+  it("resolves env with future explicit overrides", () => {
+    vi.stubEnv("CUSTOM_RATING_ENABLED", "true")
+    expect(resolveCustomRatingConfig({ endpoint: "https://other.example/{imdbId}" })).toMatchObject({ enabled: true, endpoint: "https://other.example/{imdbId}", apiKeyHeader: "X-API-Key" })
+  })
+  it.each(["::ffff:127.0.0.1", "::ffff:10.0.0.1", "::ffff:93.184.216.34"])("blocks IPv4-mapped IPv6 endpoint %s before requesting", async address => {
+    respond('{"invalid":87}')
+    expect(await fetchCustomRatings("tt123", { ...config, endpoint: `http://[${address}]/{imdbId}` })).toEqual([])
+    expect(mockedRequest).not.toHaveBeenCalled()
+  })
+  it("rejects DNS answers containing internal addresses at connection time", async () => {
+    for (const address of ["127.0.0.1", "10.0.0.1", "::1", "::ffff:127.0.0.1", "::ffff:10.0.0.1", "::ffff:93.184.216.34", "fc00::1", "fe80::1"]) {
+      vi.mocked(lookup).mockImplementationOnce(((_host: string, _options: unknown, callback: (error: null, addresses: { address: string; family: number }[]) => void) => {
+        callback(null, [{ address: "93.184.216.34", family: 4 }, { address, family: address.includes(":") ? 6 : 4 }])
+      }) as typeof lookup)
+      await new Promise<void>(resolve => {
+        connection.lookup!("example.com", { all: true }, error => {
+          expect(error).toBeInstanceOf(Error)
+          resolve()
+        })
+      })
+    }
+  })
+  it("renders more than two pills within the canvas, including escaped names", async () => {
+    const row = await renderMultiRatings([1, 2, 3].map(value => ({ id: String(value), name: "A & <B>", value, format: "decimal" })), 460)
+    expect(row).not.toBeNull()
+    const metadata = await sharp(row!.png).metadata()
+    expect(metadata.width).toBeLessThanOrEqual(460)
+    expect(metadata.height).toBe(row!.h)
+    expect(await renderMultiRatings([], 460)).toBeNull()
+  })
+})

--- a/src/__tests__/poster-route-mapping.test.ts
+++ b/src/__tests__/poster-route-mapping.test.ts
@@ -10,6 +10,15 @@ import { fetchMDBList } from "@/lib/mdblist"
 import { cacheClear } from "@/lib/cache"
 import { __resetTMDBSessionCache } from "@/lib/tmdb-session-cache"
 import type { Mapping } from "@/lib/types"
+import { fetchCustomRatings } from "@/lib/custom-rating"
+import { renderMultiRatings } from "@/lib/multi-rating-renderer"
+import { fetchAggregatedRating } from "@/lib/ratings"
+
+vi.mock("@/lib/custom-rating", async (importOriginal) => ({
+  ...await importOriginal<typeof import("@/lib/custom-rating")>(),
+  fetchCustomRatings: vi.fn(async () => []),
+}))
+vi.mock("@/lib/multi-rating-renderer", () => ({ renderMultiRatings: vi.fn(async () => null) }))
 
 vi.mock("@/lib/rate-limit", () => ({
   rateLimit: vi.fn(() => ({ ok: true, retAfter: 0 })),
@@ -95,6 +104,10 @@ async function imageBuffer(color: string, width: number, height: number): Promis
 describe("GET /api/poster/[type]/[id] with saved mappings", () => {
   beforeEach(() => {
     vi.restoreAllMocks()
+    vi.mocked(fetchCustomRatings).mockReset().mockResolvedValue([])
+    vi.mocked(fetchAggregatedRating).mockReset().mockResolvedValue(null)
+    vi.mocked(renderMultiRatings).mockClear()
+    vi.stubEnv("CUSTOM_RATING_ENABLED", "false")
   })
 
   afterEach(() => {
@@ -138,6 +151,37 @@ describe("GET /api/poster/[type]/[id] with saved mappings", () => {
     expect(mockedSelectBestLogoFitPosterPath).not.toHaveBeenCalled()
     expect(requestedUrls.some((url) => url.includes("/saved-choice.jpg"))).toBe(true)
     expect(requestedUrls.some((url) => url.includes("/best-fit.jpg"))).toBe(false)
+    expect(renderMultiRatings).not.toHaveBeenCalled()
+  })
+
+  it("passes custom ratings to the renderer on a miss and skips the provider on a cache hit", async () => {
+    vi.stubEnv("CUSTOM_RATING_ENABLED", "true")
+    vi.stubEnv("CUSTOM_RATING_ENDPOINT", "https://example.com/{imdbId}")
+    const rating = { id: "custom", name: "Example", value: 87, format: "percent" as const }
+    vi.mocked(fetchCustomRatings).mockResolvedValue([rating])
+    mockedGetExternalIds.mockResolvedValueOnce({ imdb_id: "tt1375666" })
+    mockedGetDetails.mockResolvedValueOnce({ id: 98765, title: "Custom test", genres: [], vote_average: 0, vote_count: 0 })
+    mockedGetById.mockResolvedValue({
+      tmdbId: 98765, mediaType: "movie", title: "Custom test", posterPath: "/custom-test.jpg",
+      logoPath: null, originalPosterPath: null, language: "it", showBadges: false,
+      rankingBadges: false, updatedAt: "2026-09-12T00:00:00.000Z",
+    })
+    const poster = await imageBuffer("#101010", 500, 750)
+    vi.spyOn(globalThis, "fetch").mockResolvedValue(new Response(new Uint8Array(poster), {
+      headers: { "content-type": "image/png" },
+    }))
+    const requestPoster = () => GET(new NextRequest("http://localhost:3000/api/poster/movie/98765?imdbId=tt1375666"), {
+      params: Promise.resolve({ type: "movie", id: "98765" }),
+    })
+    const first = await requestPoster()
+    expect(first.status).toBe(200)
+    expect(fetchCustomRatings).toHaveBeenCalledWith("tt1375666", expect.objectContaining({ enabled: true }), expect.any(AbortSignal))
+    expect(renderMultiRatings).toHaveBeenCalledWith([rating], expect.any(Number))
+    const calls = vi.mocked(fetchCustomRatings).mock.calls.length
+    const hit = await requestPoster()
+    expect(hit.status).toBe(200)
+    expect(fetchCustomRatings).toHaveBeenCalledTimes(calls)
+    expect(hit.headers.get("etag")).toBe(first.headers.get("etag"))
   })
 
   it("retries Block B getDetails once on transient failure", async () => {
@@ -299,6 +343,69 @@ describe("GET /api/poster/[type]/[id] with saved mappings", () => {
     // Deve usare il poster in lingua, NON il clean senza logo
     expect(requestedUrls.some((url) => url.includes("/it-poster.jpg"))).toBe(true)
     expect(requestedUrls.some((url) => url.includes("/clean.jpg"))).toBe(false)
+  })
+
+  it.each([
+    { label: "disabled", enabled: false, imdb: true, custom: true, id: 98769 },
+    { label: "IMDb + Custom", enabled: true, imdb: true, custom: true, id: 98770 },
+    { label: "IMDb only", enabled: true, imdb: true, custom: false, id: 98771 },
+    { label: "Custom only", enabled: true, imdb: false, custom: true, id: 98772 },
+    { label: "no ratings", enabled: true, imdb: false, custom: false, id: 98773 },
+    { label: "provider overrides internal ID with multiple items", enabled: true, imdb: true, custom: true, id: 98774 },
+  ].flatMap(test => ["non-mapped", "saved", "query"].map((kind, index) => ({ ...test, kind, id: test.id + index * 100 }))))("renders independent rating items: $kind / $label", async ({ imdb, custom, id, enabled, kind, label }) => {
+    vi.stubEnv("CUSTOM_RATING_ENABLED", String(enabled))
+    const { fetchAggregatedRating } = await import("@/lib/ratings")
+    vi.mocked(fetchAggregatedRating).mockResolvedValue({
+      sources: imdb ? { imdb: 8.8, tmdb: 6 } : { tmdb: 6 },
+      average: imdb ? 7.4 : 6, count: imdb ? 2 : 1,
+    })
+    const customItem = { id: "custom", name: "Custom", value: 87, format: "percent" as const }
+    const overridesInternal = label.startsWith("provider overrides")
+    const providerItems = overridesInternal ? [
+      { id: "source1", name: "Source 1", value: 8, format: "decimal" as const },
+      { id: "imdb", name: "Provider value", value: 9.2, format: "decimal" as const },
+      { id: "source2", name: "Source 2", value: 87, format: "percent" as const },
+    ] : custom ? [customItem] : []
+    vi.mocked(fetchCustomRatings).mockResolvedValueOnce(providerItems)
+    mockedGetById.mockResolvedValue(kind === "saved" ? {
+      tmdbId: id, mediaType: "movie", title: "Independent ratings", posterPath: `/ratings-${id}.jpg`,
+      logoPath: null, originalPosterPath: null, language: "it", voteAverage: 5,
+      showBadges: false, rankingBadges: false, updatedAt: "2026-09-12T00:00:00.000Z",
+    } : null)
+    mockedGetDetails.mockResolvedValue({ id, title: "Independent ratings", genres: [], vote_average: 6, vote_count: 100 })
+    mockedGetImages.mockResolvedValue({ id, posters: [
+      { file_path: `/ratings-${id}.jpg`, iso_639_1: null, vote_average: 8, vote_count: 100, width: 500, height: 750, aspect_ratio: 0.667 },
+    ], logos: [], backdrops: [] })
+    mockedGetExternalIds.mockResolvedValue({ imdb_id: `tt${id}` })
+    const poster = await imageBuffer("#101010", 500, 750)
+    vi.spyOn(globalThis, "fetch").mockImplementation(async () => new Response(new Uint8Array(poster), {
+      headers: { "content-type": "image/png" },
+    }))
+    const url = `http://localhost:3000/api/poster/movie/${id}${kind === "query" ? `?poster=/ratings-${id}.jpg&imdbId=tt${id}&voteAverage=5&preview=1` : ""}`
+    const res = await GET(new NextRequest(url), {
+      params: Promise.resolve({ type: "movie", id: String(id) }),
+    })
+    expect(res.status).toBe(200)
+    const expected = overridesInternal ? [providerItems[1], providerItems[0], providerItems[2]] : [
+      ...(imdb ? [{ id: "imdb", name: "IMDb", value: 8.8, format: "decimal" }] : []),
+      ...(custom ? [customItem] : []),
+    ]
+    if (enabled && expected.length) expect(renderMultiRatings).toHaveBeenCalledWith(expected, expect.any(Number))
+    else expect(renderMultiRatings).not.toHaveBeenCalled()
+    if (!enabled) expect(fetchCustomRatings).not.toHaveBeenCalled()
+    const imdbCalls = vi.mocked(fetchAggregatedRating).mock.calls.length
+    const customCalls = vi.mocked(fetchCustomRatings).mock.calls.length
+    if (enabled || kind === "non-mapped") expect(imdbCalls).toBe(1)
+    else expect(imdbCalls).toBe(0)
+    const hit = await GET(new NextRequest(url), { params: Promise.resolve({ type: "movie", id: String(id) }) })
+    expect(hit.status).toBe(200)
+    expect(fetchAggregatedRating).toHaveBeenCalledTimes(imdbCalls)
+    expect(fetchCustomRatings).toHaveBeenCalledTimes(customCalls)
+    const debug = await GET(new NextRequest(`${url}${url.includes("?") ? "&" : "?"}debug=1`), {
+      params: Promise.resolve({ type: "movie", id: String(id) }),
+    })
+    expect(debug.status).toBe(200)
+    expect((await debug.json()).vote.average).toBeCloseTo(kind === "non-mapped" ? (imdb ? 7.4 : 6) : 5)
   })
 
   it("applies the TMDB+IMDb average rating when the aggregated rating resolves", async () => {

--- a/src/__tests__/poster-route-mapping.test.ts
+++ b/src/__tests__/poster-route-mapping.test.ts
@@ -107,7 +107,7 @@ describe("GET /api/poster/[type]/[id] with saved mappings", () => {
     vi.mocked(fetchCustomRatings).mockReset().mockResolvedValue([])
     vi.mocked(fetchAggregatedRating).mockReset().mockResolvedValue(null)
     vi.mocked(renderMultiRatings).mockClear()
-    vi.stubEnv("CUSTOM_RATING_ENABLED", "false")
+    vi.stubEnv("PICTORIUM_CUSTOM_RATING_ENABLED", "false")
   })
 
   afterEach(() => {
@@ -155,8 +155,8 @@ describe("GET /api/poster/[type]/[id] with saved mappings", () => {
   })
 
   it("passes custom ratings to the renderer on a miss and skips the provider on a cache hit", async () => {
-    vi.stubEnv("CUSTOM_RATING_ENABLED", "true")
-    vi.stubEnv("CUSTOM_RATING_ENDPOINT", "https://example.com/{imdbId}")
+    vi.stubEnv("PICTORIUM_CUSTOM_RATING_ENABLED", "true")
+    vi.stubEnv("PICTORIUM_CUSTOM_RATING_ENDPOINT", "https://example.com/{imdbId}")
     const rating = { id: "custom", name: "Example", value: 87, format: "percent" as const }
     vi.mocked(fetchCustomRatings).mockResolvedValue([rating])
     mockedGetExternalIds.mockResolvedValueOnce({ imdb_id: "tt1375666" })
@@ -353,7 +353,7 @@ describe("GET /api/poster/[type]/[id] with saved mappings", () => {
     { label: "no ratings", enabled: true, imdb: false, custom: false, id: 98773 },
     { label: "provider overrides internal ID with multiple items", enabled: true, imdb: true, custom: true, id: 98774 },
   ].flatMap(test => ["non-mapped", "saved", "query"].map((kind, index) => ({ ...test, kind, id: test.id + index * 100 }))))("renders independent rating items: $kind / $label", async ({ imdb, custom, id, enabled, kind, label }) => {
-    vi.stubEnv("CUSTOM_RATING_ENABLED", String(enabled))
+    vi.stubEnv("PICTORIUM_CUSTOM_RATING_ENABLED", String(enabled))
     const { fetchAggregatedRating } = await import("@/lib/ratings")
     vi.mocked(fetchAggregatedRating).mockResolvedValue({
       sources: imdb ? { imdb: 8.8, tmdb: 6 } : { tmdb: 6 },
@@ -664,6 +664,54 @@ describe("GET /api/poster/[type]/[id] error and edge cases", () => {
     expect(res.headers.get("Access-Control-Allow-Origin")).toBe("*")
   })
 
+  it("revalidates saved custom ratings after cache eviction, including the empty state", async () => {
+    vi.stubEnv("PICTORIUM_CUSTOM_RATING_ENABLED", "true")
+    const id = 98999
+    mockedGetById.mockResolvedValue({
+      tmdbId: id, mediaType: "movie", title: "Revalidation", posterPath: "/revalidate.jpg",
+      logoPath: null, originalPosterPath: null, language: "it", showBadges: false,
+      rankingBadges: false, updatedAt: "2026-09-12T00:00:00.000Z",
+    })
+    mockedGetExternalIds.mockResolvedValue({ imdb_id: "tt98999" })
+    mockedGetDetails.mockResolvedValue({ id, genres: [], vote_average: 5, vote_count: 10 })
+    const poster = await imageBuffer("#101010", 500, 750)
+    vi.spyOn(globalThis, "fetch").mockImplementation(async () => new Response(new Uint8Array(poster), {
+      headers: { "content-type": "image/png" },
+    }))
+    const request = (etag?: string) => GET(new NextRequest(`http://localhost:3000/api/poster/movie/${id}`, {
+      headers: etag ? { "If-None-Match": etag } : {},
+    }), { params: Promise.resolve({ type: "movie", id: String(id) }) })
+    const first = await request()
+    expect(first.status).toBe(200)
+    const emptyEtag = first.headers.get("etag")!
+    expect(emptyEtag).toMatch(/:cr[^\"]+"$/)
+    expect(fetchCustomRatings).toHaveBeenCalledTimes(1)
+    expect((await request(emptyEtag)).status).toBe(304)
+    expect(fetchCustomRatings).toHaveBeenCalledTimes(1) // Cache HIT stays a fast path.
+    cacheClear()
+    expect((await request(emptyEtag)).status).toBe(304)
+    expect(fetchCustomRatings).toHaveBeenCalledTimes(2) // Empty state revalidated.
+
+    const item = { id: "source1", name: "Source 1", value: 87, format: "percent" as const }
+    vi.mocked(fetchCustomRatings).mockResolvedValue([item])
+    let populatedEtag = ""
+    // Also cover clients holding a pre-fix ETag without the empty-state suffix.
+    for (const previousEtag of [emptyEtag, emptyEtag.replace(/:cr[^\"]+"$/, '"')]) {
+      cacheClear()
+      const calls = vi.mocked(fetchCustomRatings).mock.calls.length
+      const next = await request(previousEtag)
+      expect(next.status).toBe(200)
+      expect(fetchCustomRatings).toHaveBeenCalledTimes(calls + 1)
+      expect(renderMultiRatings).toHaveBeenLastCalledWith([item], expect.any(Number))
+      populatedEtag = next.headers.get("etag")!
+      expect(populatedEtag).not.toBe(emptyEtag)
+    }
+    cacheClear()
+    const calls = vi.mocked(fetchCustomRatings).mock.calls.length
+    expect((await request(populatedEtag)).status).toBe(304)
+    expect(fetchCustomRatings).toHaveBeenCalledTimes(calls + 1)
+  })
+
   it("returns 304 Not Modified when etag matches", async () => {
     const posterBuf = await imageBuffer("#101010", 500, 750)
 
@@ -692,6 +740,7 @@ describe("GET /api/poster/[type]/[id] error and edge cases", () => {
     const etag = res1.headers.get("ETag")
     expect(etag).toBeTruthy()
 
+    cacheClear() // Disabled provider preserves mapped early 304 even on a cache miss.
     // Second request with If-None-Match
     const req2 = new NextRequest("http://localhost:3000/api/poster/movie/42", {
       headers: { "If-None-Match": etag! },

--- a/src/__tests__/poster-route-mapping.test.ts
+++ b/src/__tests__/poster-route-mapping.test.ts
@@ -13,6 +13,8 @@ import type { Mapping } from "@/lib/types"
 import { fetchCustomRatings } from "@/lib/custom-rating"
 import { renderMultiRatings } from "@/lib/multi-rating-renderer"
 import { fetchAggregatedRating } from "@/lib/ratings"
+import { RENDER_VERSION } from "@/lib/render-version"
+import { posterHeaders } from "@/lib/poster-runtime-cache"
 
 vi.mock("@/lib/custom-rating", async (importOriginal) => ({
   ...await importOriginal<typeof import("@/lib/custom-rating")>(),
@@ -662,6 +664,48 @@ describe("GET /api/poster/[type]/[id] error and edge cases", () => {
     const res = await GET(req, { params: Promise.resolve({ type: "movie", id: "0" }) })
     expect(res.status).toBe(400)
     expect(res.headers.get("Access-Control-Allow-Origin")).toBe("*")
+  })
+
+  it.each([true, false])("uses the correct mapped HTTP cache policy with custom provider enabled=%s", async enabled => {
+    vi.mocked(fetchCustomRatings).mockClear()
+    vi.stubEnv("PICTORIUM_CUSTOM_RATING_ENABLED", String(enabled))
+    const id = 99001
+    const updatedAt = "2026-09-12T00:00:00.000Z"
+    mockedGetById.mockResolvedValue({
+      tmdbId: id, mediaType: "movie", title: "Cache policy", posterPath: "/cache-policy.jpg",
+      logoPath: null, originalPosterPath: null, language: "it", showBadges: false,
+      rankingBadges: false, updatedAt,
+    })
+    mockedGetExternalIds.mockResolvedValue({ imdb_id: "tt99001" })
+    mockedGetDetails.mockResolvedValue({ id, genres: [], vote_average: 5, vote_count: 10 })
+    const poster = await imageBuffer("#101010", 500, 750)
+    vi.spyOn(globalThis, "fetch").mockImplementation(async () => new Response(new Uint8Array(poster), {
+      headers: { "content-type": "image/png" },
+    }))
+    const request = (etag?: string) => GET(new NextRequest(
+      `http://localhost:3000/api/poster/movie/${id}?rv=${RENDER_VERSION}&mv=${Date.parse(updatedAt)}`,
+      { headers: etag ? { "If-None-Match": etag } : {} },
+    ), { params: Promise.resolve({ type: "movie", id: String(id) }) })
+    const first = await request()
+    expect(first.status).toBe(200)
+    const calls = vi.mocked(fetchCustomRatings).mock.calls.length
+    const hit = await request()
+    const conditionalHit = await request(first.headers.get("etag")!)
+    expect(hit.status).toBe(200)
+    expect(conditionalHit.status).toBe(304)
+    expect(fetchCustomRatings).toHaveBeenCalledTimes(calls)
+    for (const response of [first, hit, conditionalHit]) {
+      const policy = response.headers.get("cache-control")!
+      expect(policy).toBe(posterHeaders("test", !enabled)["Cache-Control"])
+      if (enabled) {
+        expect(policy).not.toContain("immutable")
+        expect(policy).not.toContain("max-age=31536000")
+      } else {
+        expect(policy).toContain("immutable")
+        expect(policy).toContain("max-age=31536000")
+      }
+    }
+    vi.mocked(fetchCustomRatings).mockClear()
   })
 
   it("revalidates saved custom ratings after cache eviction, including the empty state", async () => {

--- a/src/app/api/poster/[type]/[id]/route.ts
+++ b/src/app/api/poster/[type]/[id]/route.ts
@@ -67,6 +67,8 @@ import { resolvePosterRenderConfig } from "@/lib/poster-config"
 import { selectBestLogo, logoBestLogoFallbackReason } from "@/lib/logo-selection"
 import { resolveStreamQuality } from "@/lib/stream-quality"
 import { combineAbortSignals } from "@/lib/abort-signal"
+import { createHash } from "node:crypto"
+import { fetchCustomRatings, resolveCustomRatingConfig, type RatingItem } from "@/lib/custom-rating"
 
 // Vercel: limite massimo di esecuzione della funzione. Il render poster ha un
 // deadline interno di 30s (PICTORIUM_RENDER_TIMEOUT_MS) → 40s copre il caso
@@ -196,7 +198,10 @@ export async function GET(req: NextRequest, { params }: { params: Promise<RouteP
   }
 
   // 2. Cache key
-  const sdHash = hashKey(JSON.stringify(sd))
+  const customRatingConfig = resolveCustomRatingConfig()
+  const customRatingHash = customRatingConfig.enabled
+    ? createHash("sha256").update(JSON.stringify(customRatingConfig)).digest("hex") : ""
+  const sdHash = hashKey(JSON.stringify(sd) + customRatingHash)
   const cacheParams = normalizePosterCacheParams(req.nextUrl.searchParams)
   cacheParams.delete("config")
   cacheParams.delete("c")
@@ -390,6 +395,8 @@ export async function GET(req: NextRequest, { params }: { params: Promise<RouteP
   // renderAbort non viene mai abortito a render riuscito → il controller va
   // abortito subito dopo la race per non lasciare il fetch orfano in background.
   let aggregatedRating: ReturnType<typeof fetchAggregatedRating> | null = null
+  let multiRatingOnly = false
+  const ratings: RatingItem[] = []
   let ratingAbort: AbortController | null = null
   let showBadges = true
   let rankingBadges = true
@@ -874,7 +881,7 @@ export async function GET(req: NextRequest, { params }: { params: Promise<RouteP
           ? getKeywords(mediaType, tmdbId, resolveRequestApiKey(req), renderAbort.signal, POSTER_TMDB_TIMEOUT_MS).catch(() => [])
           : Promise.resolve([]),
         (async () => {
-          if (!rankingEnabledEarly) return false
+          if (!rankingEnabledEarly && !customRatingConfig.enabled) return false
           if (!imdbId) {
             // F6: externalIds già in session cache (ramo non-mappato) → niente rete.
             const extIds = getTMDBSessionCache(mediaType, tmdbId)?.externalIds
@@ -882,7 +889,17 @@ export async function GET(req: NextRequest, { params }: { params: Promise<RouteP
             if (extIds?.imdb_id) imdbId = extIds.imdb_id
           }
           if (!imdbId) return false
-          return isImdbTop250(imdbId, renderAbort.signal)
+          if (customRatingConfig.enabled && !aggregatedRating) {
+            // Saved/query posters need source data only; keep their legacy vote intact.
+            multiRatingOnly = true
+            ratingAbort = new AbortController()
+            aggregatedRating = fetchAggregatedRating(
+              imdbId,
+              req.nextUrl.searchParams.get("mdblist_key") || envWithFallback("MDBLIST_KEY") || undefined,
+              combineAbortSignals(AbortSignal.any([renderAbort.signal, ratingAbort.signal]), RATING_WAIT_MS),
+            ).catch(() => null)
+          }
+          return rankingEnabledEarly ? isImdbTop250(imdbId, renderAbort.signal) : false
         })(),
       ]),
     ])
@@ -899,8 +916,14 @@ export async function GET(req: NextRequest, { params }: { params: Promise<RouteP
       })
       const aggregated = await Promise.race([aggregatedRating, ratingTimeout])
       if (ratingTimer) clearTimeout(ratingTimer)
-      const avgVote = calculateAverageRating(aggregated, reqRatingSources)
-      if (typeof avgVote === "number" && avgVote > 0) voteAverage = avgVote
+      const imdbRating = aggregated?.sources.imdb
+      if (customRatingConfig.enabled && typeof imdbRating === "number" && Number.isFinite(imdbRating) && imdbRating > 0 && imdbRating <= 10) {
+        ratings.push({ id: "imdb", name: "IMDb", value: imdbRating, format: "decimal" })
+      }
+      if (!multiRatingOnly) {
+        const avgVote = calculateAverageRating(aggregated, reqRatingSources)
+        if (typeof avgVote === "number" && avgVote > 0) voteAverage = avgVote
+      }
       ratingAbort?.abort()
     }
 
@@ -939,7 +962,8 @@ export async function GET(req: NextRequest, { params }: { params: Promise<RouteP
     if (mapping?.firstAirDate) firstAirDate = mapping.firstAirDate
 
     // Luminance + optional TV details fetch (parallel, independent)
-    const [topLum] = await Promise.all([
+    const [customRatings, topLum] = await Promise.all([
+      customRatingConfig.enabled ? fetchCustomRatings(imdbId, customRatingConfig, renderAbort.signal) : Promise.resolve([]),
       (async (): Promise<number | null> => {
         if (qTopLight === "1" || qTopLight === "0" || qTopLight === "true" || qTopLight === "false") return null
         return await topLuminance(posterBuf)
@@ -1146,6 +1170,8 @@ export async function GET(req: NextRequest, { params }: { params: Promise<RouteP
 
     // 10. Generate poster buffer
     const genInput: GenerationInput = {
+      // Custom values override internal sources with the same ID, preserving order.
+      ratings: customRatingConfig.enabled ? [...new Map([...ratings, ...customRatings].map(item => [item.id, item])).values()] : undefined,
       posterBuf, logoFetch, backdropFetch,
       backdropScale, backdropOffsetX, backdropOffsetY,
       blurEnabled, blurHeight, blurIntensity, blurFade, blurDarkness,
@@ -1177,6 +1203,9 @@ export async function GET(req: NextRequest, { params }: { params: Promise<RouteP
       throw new Error("Render deadline exceeded before poster compositing")
     }
     const composited = await generatePosterBuffer(genInput)
+    if (genInput.ratings?.length) {
+      etag = `${etag.slice(0, -1)}:cr${hashKey(JSON.stringify(genInput.ratings))}"`
+    }
 
     // 10. Fix stale auto ETag: include dynamic data (rank, rating) so when it re-renders, the ETag changes
     if (!mapping && !isPreview) {

--- a/src/app/api/poster/[type]/[id]/route.ts
+++ b/src/app/api/poster/[type]/[id]/route.ts
@@ -224,7 +224,7 @@ export async function GET(req: NextRequest, { params }: { params: Promise<RouteP
   const variantKey = outputFormat === "webp" ? `${cacheKey}:fmtwebp` : cacheKey
   const etagBase = hashKey(`v${RENDER_VERSION}:${mediaType}:${tmdbId}:reg${posterRegion.code}:r${cachedRank ?? "x"}:sd${sdHash}:${cacheParams.toString()}${configHash ? `:${configHash}` : ""}`)
   const currentMappingVersion = mappingVersionParam(mapping)
-  const immutablePoster = isImmutablePosterRequest(req.nextUrl.searchParams, {
+  const immutablePoster = !customRatingConfig.enabled && isImmutablePosterRequest(req.nextUrl.searchParams, {
     hasMapping: !!mapping,
     isRotating,
     mappingVersionMatches: !!currentMappingVersion && req.nextUrl.searchParams.get("mv") === currentMappingVersion,

--- a/src/app/api/poster/[type]/[id]/route.ts
+++ b/src/app/api/poster/[type]/[id]/route.ts
@@ -487,7 +487,7 @@ export async function GET(req: NextRequest, { params }: { params: Promise<RouteP
     showBadges = mapping.showBadges ?? true
     rankingBadges = mapping.rankingBadges ?? true
     etag = `"m${etagBase}:${mapping.updatedAt}"`
-    if (req.headers.get("If-None-Match") === etag) {
+    if (!customRatingConfig.enabled && req.headers.get("If-None-Match") === etag) {
       clearTimeout(renderDeadline)
       completePosterRender(null)
       return new Response(null, { status: 304, headers: posterNotModifiedHeaders(etag, immutablePoster, dynamicPoster) })
@@ -1203,7 +1203,7 @@ export async function GET(req: NextRequest, { params }: { params: Promise<RouteP
       throw new Error("Render deadline exceeded before poster compositing")
     }
     const composited = await generatePosterBuffer(genInput)
-    if (genInput.ratings?.length) {
+    if (customRatingConfig.enabled) {
       etag = `${etag.slice(0, -1)}:cr${hashKey(JSON.stringify(genInput.ratings))}"`
     }
 
@@ -1217,6 +1217,11 @@ export async function GET(req: NextRequest, { params }: { params: Promise<RouteP
     writeCachedPoster(cacheKey, payload, mappingTag)
     completePosterRender(payload)
     recordPosterRequest(false, outputFormat)
+    // Enabled enrichment must revalidate against the final state, including [].
+    const responseEtag = outputFormat === "webp" ? variantEtagFor(etag) : etag
+    if (customRatingConfig.enabled && !isPreview && req.headers.get("If-None-Match") === responseEtag) {
+      return new Response(null, { status: 304, headers: posterNotModifiedHeaders(responseEtag, immutablePoster, dynamicPoster) })
+    }
     log.info("Poster rendered", { mediaType, tmdbId, ms: Date.now() - startTime, bytes: composited.byteLength, cached: !!mappingTag, format: outputFormat })
     // C3: il webp è variante di risposta (convertita + cachata), non un render.
     if (outputFormat === "webp") return serveWebpVariant(payload)

--- a/src/lib/custom-rating/formatter.ts
+++ b/src/lib/custom-rating/formatter.ts
@@ -1,0 +1,5 @@
+import type { CustomRatingFormat } from "./types"
+
+export function formatRating(value: number, format: CustomRatingFormat): string {
+  return `${value}${format === "percent" ? "%" : ""}`
+}

--- a/src/lib/custom-rating/index.ts
+++ b/src/lib/custom-rating/index.ts
@@ -1,0 +1,16 @@
+import type { CustomRatingConfig } from "./types"
+
+export type { CustomRatingConfig, CustomRatingFormat, RatingItem } from "./types"
+export { formatRating } from "./formatter"
+export { fetchCustomRatings } from "./provider"
+
+/** Explicit overrides allow a future server-side token/UI resolver. */
+export function resolveCustomRatingConfig(overrides: Partial<CustomRatingConfig> = {}): CustomRatingConfig {
+  return {
+    enabled: process.env.CUSTOM_RATING_ENABLED === "true" || process.env.CUSTOM_RATING_ENABLED === "1",
+    endpoint: process.env.CUSTOM_RATING_ENDPOINT || "",
+    apiKey: process.env.CUSTOM_RATING_API_KEY || undefined,
+    apiKeyHeader: process.env.CUSTOM_RATING_API_KEY_HEADER || "X-API-Key",
+    ...overrides,
+  }
+}

--- a/src/lib/custom-rating/index.ts
+++ b/src/lib/custom-rating/index.ts
@@ -1,4 +1,5 @@
 import type { CustomRatingConfig } from "./types"
+import { envWithFallback } from "../env-compat"
 
 export type { CustomRatingConfig, CustomRatingFormat, RatingItem } from "./types"
 export { formatRating } from "./formatter"
@@ -6,11 +7,12 @@ export { fetchCustomRatings } from "./provider"
 
 /** Explicit overrides allow a future server-side token/UI resolver. */
 export function resolveCustomRatingConfig(overrides: Partial<CustomRatingConfig> = {}): CustomRatingConfig {
+  const enabled = envWithFallback("CUSTOM_RATING_ENABLED")
   return {
-    enabled: process.env.CUSTOM_RATING_ENABLED === "true" || process.env.CUSTOM_RATING_ENABLED === "1",
-    endpoint: process.env.CUSTOM_RATING_ENDPOINT || "",
-    apiKey: process.env.CUSTOM_RATING_API_KEY || undefined,
-    apiKeyHeader: process.env.CUSTOM_RATING_API_KEY_HEADER || "X-API-Key",
+    enabled: enabled === "true" || enabled === "1",
+    endpoint: envWithFallback("CUSTOM_RATING_ENDPOINT") || "",
+    apiKey: envWithFallback("CUSTOM_RATING_API_KEY") || undefined,
+    apiKeyHeader: envWithFallback("CUSTOM_RATING_API_KEY_HEADER") || "X-API-Key",
     ...overrides,
   }
 }

--- a/src/lib/custom-rating/provider.ts
+++ b/src/lib/custom-rating/provider.ts
@@ -1,0 +1,78 @@
+import { lookup } from "node:dns"
+import { BlockList, isIP } from "node:net"
+import { Agent, request } from "undici"
+import { combineAbortSignals } from "../abort-signal"
+import type { CustomRatingConfig, RatingItem } from "./types"
+
+const blocked = new BlockList()
+for (const [address, prefix] of [["0.0.0.0", 8], ["10.0.0.0", 8], ["100.64.0.0", 10], ["127.0.0.0", 8], ["169.254.0.0", 16], ["172.16.0.0", 12], ["192.168.0.0", 16], ["192.0.0.0", 24], ["198.18.0.0", 15], ["224.0.0.0", 3]] as const) blocked.addSubnet(address, prefix, "ipv4")
+blocked.addSubnet("::", 96, "ipv6")
+blocked.addSubnet("::ffff:0:0", 96, "ipv6")
+blocked.addSubnet("fc00::", 7, "ipv6")
+blocked.addSubnet("fe80::", 10, "ipv6")
+blocked.addSubnet("ff00::", 8, "ipv6")
+blocked.addSubnet("2001::", 32, "ipv6")
+blocked.addSubnet("2002::", 16, "ipv6")
+blocked.addSubnet("64:ff9b::", 96, "ipv6")
+
+function publicAddress(address: string): boolean {
+  const family = isIP(address)
+  return !!family && !blocked.check(address, family === 4 ? "ipv4" : "ipv6")
+}
+
+// Validate the address used by the socket itself, preventing DNS rebinding.
+const dispatcher = new Agent({ connect: { lookup(hostname, options, callback) {
+  lookup(hostname, { ...options, all: true }, (error, addresses) => {
+    if (error) return callback(error, [])
+    if (!addresses.length || addresses.some(({ address }) => !publicAddress(address))) {
+      return callback(new Error("Custom rating destination is not public"), [])
+    }
+    if (options.all) callback(null, addresses)
+    else callback(null, addresses[0].address, addresses[0].family)
+  })
+} } })
+
+export async function fetchCustomRatings(imdbId: string | null | undefined, config: CustomRatingConfig, signal?: AbortSignal): Promise<RatingItem[]> {
+  if (!config.enabled || !imdbId || !/^tt\d+$/.test(imdbId) || signal?.aborted) return []
+  try {
+    if (!config.endpoint.includes("{imdbId}")) return []
+    const url = new URL(config.endpoint.replaceAll("{imdbId}", imdbId))
+    if (!["http:", "https:"].includes(url.protocol) || url.username || url.password) return []
+    const host = url.hostname.replace(/^\[|\]$/g, "")
+    if (isIP(host) && !publicAddress(host)) return []
+    const headers: Record<string, string> = { accept: "application/json" }
+    if (config.apiKey) headers[config.apiKeyHeader || "X-API-Key"] = config.apiKey
+    const response = await request(url, {
+      dispatcher, headers, signal: combineAbortSignals(signal, 1500),
+      // undici.request does not follow redirects (no redirect interceptor).
+      headersTimeout: 1500, bodyTimeout: 1500,
+    })
+    try {
+      if (response.statusCode < 200 || response.statusCode >= 300) return []
+      const chunks: Buffer[] = []
+      let size = 0
+      for await (const chunk of response.body) {
+        size += chunk.length
+        if (size > 16 * 1024) return []
+        chunks.push(Buffer.from(chunk))
+      }
+      const data: unknown = JSON.parse(Buffer.concat(chunks).toString("utf8"))
+      if (!data || typeof data !== "object" || !("ratings" in data) || !Array.isArray(data.ratings)) return []
+      const ratings = new Map<string, RatingItem>()
+      for (const item of data.ratings) {
+        if (!item || typeof item !== "object" || Array.isArray(item)) continue
+        const { id, name, value, format } = item
+        if (typeof id !== "string" || !id.trim() || typeof name !== "string" || !name.trim()) continue
+        if (typeof value !== "number" || !Number.isFinite(value)) continue
+        if (format !== "decimal" && format !== "percent") continue
+        // Last valid value wins; retain the first occurrence's position.
+        ratings.set(id.trim(), { id: id.trim(), name: name.trim(), value, format })
+      }
+      return [...ratings.values()]
+    } finally {
+      response.body.destroy()
+    }
+  } catch {
+    return []
+  }
+}

--- a/src/lib/custom-rating/provider.ts
+++ b/src/lib/custom-rating/provider.ts
@@ -38,6 +38,7 @@ export async function fetchCustomRatings(imdbId: string | null | undefined, conf
     if (!config.endpoint.includes("{imdbId}")) return []
     const url = new URL(config.endpoint.replaceAll("{imdbId}", imdbId))
     if (!["http:", "https:"].includes(url.protocol) || url.username || url.password) return []
+    if (config.apiKey && url.protocol !== "https:") return []
     const host = url.hostname.replace(/^\[|\]$/g, "")
     if (isIP(host) && !publicAddress(host)) return []
     const headers: Record<string, string> = { accept: "application/json" }

--- a/src/lib/custom-rating/types.ts
+++ b/src/lib/custom-rating/types.ts
@@ -1,0 +1,17 @@
+export type CustomRatingFormat = "decimal" | "percent"
+
+export interface CustomRatingConfig {
+  enabled: boolean
+  endpoint: string
+  apiKey?: string
+  apiKeyHeader?: string
+}
+
+export interface RatingItem {
+  id: string
+  name: string
+  value: number
+  format: CustomRatingFormat
+  /** Reserved for a trusted logo asset; the initial renderer uses name. */
+  logo?: string
+}

--- a/src/lib/multi-rating-renderer.ts
+++ b/src/lib/multi-rating-renderer.ts
@@ -1,0 +1,23 @@
+import { escSvg, estimateTextWidth } from "./badge-svg-shared"
+import { renderSVG } from "./svg-badge"
+import { formatRating } from "./custom-rating/formatter"
+import type { RatingItem } from "./custom-rating/types"
+
+/** A separate horizontal row; no network or changes to legacy badge layout. */
+export async function renderMultiRatings(ratings: RatingItem[], maxWidth: number) {
+  const items = ratings.filter(item => Number.isFinite(item.value))
+  if (!items.length) return null
+  let width = 0
+  const pills = items.map(item => {
+    const label = `${item.name.slice(0, 80)} ${formatRating(item.value, item.format)}`
+    const w = Math.ceil(estimateTextWidth(label, 20)) + 28
+    const pill = `<g transform="translate(${width},0)"><rect width="${w}" height="38" rx="19" fill="#171717" fill-opacity="0.9"/><text x="${w / 2}" y="25" text-anchor="middle" font-family="Inter" font-size="20" font-weight="700" fill="white">${escSvg(label)}</text></g>`
+    width += w + 8
+    return pill
+  })
+  width -= 8
+  const w = Math.min(maxWidth, width)
+  const h = Math.max(1, Math.round(38 * w / width))
+  const png = await renderSVG(`<svg xmlns="http://www.w3.org/2000/svg" width="${w}" height="${h}" viewBox="0 0 ${width} 38">${pills.join("")}</svg>`, w)
+  return { png, w, h }
+}

--- a/src/lib/poster-service.ts
+++ b/src/lib/poster-service.ts
@@ -1,4 +1,6 @@
 import sharp from "sharp"
+import type { RatingItem } from "./custom-rating/types"
+import { renderMultiRatings } from "./multi-rating-renderer"
 import { cacheGet, cacheSet } from "./cache"
 import { GENRE_FALLBACK, cinematicVignetteSVG } from "./badges"
 import { applyBlur } from "./blur"
@@ -52,6 +54,7 @@ const IMAGE_CACHE_TTL = 24 * 60 * 60 * 1000
 const IMAGE_CACHE_TAG = "poster-extract"
 
 export interface GenerationInput {
+  ratings?: RatingItem[]
   // Images (already fetched)
   posterBuf: Buffer
   logoFetch: Buffer | null
@@ -821,6 +824,17 @@ export async function generatePosterBuffer(input: GenerationInput): Promise<Buff
       // Offset solo stili centrati: la barra resta ancorata full-width.
       const badgeY = STD_H - safeGenreBadgeResult.h - Math.max(0, Math.round(targetCenter - safeGenreBadgeResult.h / 2)) + genreBadgeOffsetY
       composites.push({ input: safeGenreBadgeResult.png, top: badgeY, left: Math.round((STD_W - safeGenreBadgeResult.w) / 2) + genreBadgeOffsetX })
+    }
+  }
+  if (input.ratings?.length) {
+    // Optional enrichment must never prevent the original poster from rendering.
+    const row = await renderMultiRatings(input.ratings, STD_W - 40).catch(() => null)
+    if (row) {
+      const legacyTop = safeGenreBadgeResult
+        ? (badgeStyle === "bar" ? STD_H - safeGenreBadgeResult.h
+          : STD_H - safeGenreBadgeResult.h - Math.max(0, Math.round(targetCenter - safeGenreBadgeResult.h / 2)) + genreBadgeOffsetY)
+        : STD_H - 20
+      composites.push({ input: row.png, left: Math.round((STD_W - row.w) / 2), top: Math.max(0, legacyTop - row.h - 10) })
     }
   }
   const isRightRibbon = ribbonSide === "right"


### PR DESCRIPTION
## Summary
Adds a generic server-side Custom Rating Provider for poster rendering.

The provider can fetch multiple independent ratings from any external HTTP(S) API using the title's IMDb ID.

Example response:

```json
{
  "ratings": [
    { "id": "source1", "name": "Source 1", "value": 8.8, "format": "decimal" },
    { "id": "source2", "name": "Source 2", "value": 87, "format": "percent" }
  ]
}
```

## Included
- Generic `RatingItem[]` model with no fixed number of ratings
- Multiple ratings from a single provider request
- Decimal and percentage formatting
- Optional API-key authentication via HTTP header
- Separate multi-rating pill renderer
- Internal IMDb rating can be combined with provider ratings
- Provider items can override an internal item with the same `id`
- Works for non-mapped, saved and query/preview posters
- Provider failures are non-blocking
- Cache-hit fast path remains before external rating fetching
- SSRF protection, timeout and response-size limits
- Existing TMDb/MDBList `voteAverage` behavior remains unchanged
- Documentation and tests included

## Configuration
Configuration is currently server-side via environment variables:

- `CUSTOM_RATING_ENABLED`
- `CUSTOM_RATING_ENDPOINT`
- `CUSTOM_RATING_API_KEY`
- `CUSTOM_RATING_API_KEY_HEADER`

Web/editor configuration is intentionally not included in this PR to keep the backend change focused and easier to review. It can be added separately if this approach is accepted.

## Validation
- Custom rating/provider tests pass
- Poster route tests pass
- TypeScript passes
- ESLint passes
- `git diff --check` passes