### PR TITLE
fix(custom-rating): allow public IPv4 provider endpoints

### DIFF
--- a/src/lib/custom-rating/provider.ts
+++ b/src/lib/custom-rating/provider.ts
@@ -7,7 +7,6 @@ import type { CustomRatingConfig, RatingItem } from "./types"
 const blocked = new BlockList()
 for (const [address, prefix] of [["0.0.0.0", 8], ["10.0.0.0", 8], ["100.64.0.0", 10], ["127.0.0.0", 8], ["169.254.0.0", 16], ["172.16.0.0", 12], ["192.168.0.0", 16], ["192.0.0.0", 24], ["198.18.0.0", 15], ["224.0.0.0", 3]] as const) blocked.addSubnet(address, prefix, "ipv4")
 blocked.addSubnet("::", 96, "ipv6")
-blocked.addSubnet("::ffff:0:0", 96, "ipv6")
 blocked.addSubnet("fc00::", 7, "ipv6")
 blocked.addSubnet("fe80::", 10, "ipv6")
 blocked.addSubnet("ff00::", 8, "ipv6")


### PR DESCRIPTION
Fixes Custom Rating Provider requests being incorrectly blocked by the SSRF protection.

The blanket IPv6 rule:

blocked.addSubnet("::ffff:0:0", 96, "ipv6")

causes Node's net.BlockList to reject public IPv4 destinations as IPv4-mapped IPv6 addresses.

This was reproduced with the provider endpoint resolving to public IPv4 addresses:

104.21.95.211
172.67.148.158

Both were incorrectly classified as non-public, causing the "Test provider" flow to return "Provider unreachable".

A normal undici.request() to the same endpoint returned HTTP 200.

Removing the blanket mapped-IPv4 rule restores public IPv4 provider access, while the existing IPv4 private/reserved subnet rules continue to block private destinations.